### PR TITLE
Add setting for padding of hours in 24 hours mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,39 @@
 {
   "name": "yaclock",
   "version": "1.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@types/vscode": {
+  "packages": {
+    "": {
+      "name": "yaclock",
+      "version": "1.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/vscode": "^1.32.0",
+        "typescript": "^4.1.3"
+      },
+      "engines": {
+        "vscode": "^1.32.0"
+      }
+    },
+    "node_modules/@types/vscode": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
       "integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
       "dev": true
     },
-    "typescript": {
+    "node_modules/typescript": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
       "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yaclock",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "displayName": "Clock",
   "description": "Yet Another Clock for Visual Studio Code in the status bar",
   "main": "out/extension.js",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
           "type": "boolean",
           "default": false
         },
+        "yaclock.padHour24": {
+          "description": "Zero-pad one-digit hours in 24 hrs mode.",
+          "type": "boolean",
+          "default": false
+        },
         "yaclock.showDay": {
           "description": "Show the day of the week.",
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "vscode": "^1.32.0"
   },
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "publisher": "jameslan",
   "icon": "images/icon.png",

--- a/src/clock.ts
+++ b/src/clock.ts
@@ -9,6 +9,7 @@ export class Clock {
     prefix: string;
     postfix: string;
     hour12: boolean;
+    padHour24: boolean;
     showAmPm: boolean;
     showDate: boolean;
     showDay: boolean;
@@ -21,6 +22,7 @@ export class Clock {
         this.prefix = config.get('prefix', '');
         this.postfix = config.get('postfix', '');
         this.hour12 = config.get('hour12', false);
+        this.padHour24 = config.get('padHour24', false);
         this.showAmPm = this.hour12 && config.get('showAmPm', false);
         this.showDate = config.get('showDate', false);
         this.showDay = config.get('showDay', false);
@@ -58,7 +60,12 @@ export class Clock {
         if (this.flash) {
             this.showSeparator = !this.showSeparator;
         }
-        const hour = this.hour12 ? (time.getHours() + 11) % 12 + 1 : time.getHours();
+        let hour: number|string = time.getHours();;
+        if (this.hour12) {
+            hour = (hour + 11) % 12 + 1;
+        } else if (this.padHour24) {
+            hour = hour.toString().padStart(2, '0');
+        }
         const minute = time.getMinutes().toString().padStart(2, '0');
         const second = this.showSecond ? separator + time.getSeconds().toString().padStart(2, '0') : '';
         const ampm = this.showAmPm ? (time.getHours() < 12 ? ' AM' : ' PM') : '';


### PR DESCRIPTION
When using 24 hours mode it's common to zero-pad the hours, e.g. "08:37".
This PR adds a setting for doing this.

Since I got a warning about using "*" as activation event that was also changed to "onStartupFinished".